### PR TITLE
[Feat]#40 - api setting

### DIFF
--- a/src/apis/cake/postCake.ts
+++ b/src/apis/cake/postCake.ts
@@ -1,0 +1,27 @@
+import { postResponse } from "../instance";
+
+export const postCake = async (cakeName: string): Promise<number | null> => {
+  const colorMapping: { [key: string]: string } = {
+    "부드러운 스트로베리": "STRAWBERRY",
+    "상큼한 레몬": "LEMON",
+    "깔끔한 녹차": "MATCHA",
+    "유쾌한 티라미수": "TIRAMISU",
+    "순백의 생크림": "WHIPPED_CREAM",
+    "조화로운 블루베리": "BLUEBERRY",
+    "신중한 피스타치오": "PISTACHIO",
+    "논리적인 초코": "CHOCOLATE",
+  };
+
+  const color = colorMapping[cakeName] || "STRAWBERRY";
+
+  const response = await postResponse<{ color: string }, { cakeId: number }>(
+    "/api/cakes",
+    { color }
+  );
+  if (response) {
+    localStorage.setItem("cakeId", response.cakeId.toString());
+    return response.cakeId;
+  }
+
+  return null;
+};

--- a/src/apis/cake/postCake.ts
+++ b/src/apis/cake/postCake.ts
@@ -4,9 +4,9 @@ export const postCake = async (cakeName: string): Promise<number | null> => {
   const colorMapping: { [key: string]: string } = {
     "부드러운 스트로베리": "STRAWBERRY",
     "상큼한 레몬": "LEMON",
-    "깔끔한 녹차": "MATCHA",
+    "깔끔한 녹차": "GREEN_TEA",
     "유쾌한 티라미수": "TIRAMISU",
-    "순백의 생크림": "WHIPPED_CREAM",
+    "순백의 생크림": "CREAM",
     "조화로운 블루베리": "BLUEBERRY",
     "신중한 피스타치오": "PISTACHIO",
     "논리적인 초코": "CHOCOLATE",

--- a/src/apis/domain/cake/postCake.ts
+++ b/src/apis/domain/cake/postCake.ts
@@ -1,4 +1,4 @@
-import { postResponse } from "../instance";
+import { postResponse } from "@apis/instance";
 
 export const postCake = async (cakeName: string): Promise<number | null> => {
   const colorMapping: { [key: string]: string } = {
@@ -12,15 +12,16 @@ export const postCake = async (cakeName: string): Promise<number | null> => {
     "논리적인 초코": "CHOCOLATE",
   };
 
-  const color = colorMapping[cakeName] || "STRAWBERRY";
+  const color = colorMapping[cakeName] || "NOTHING";
 
-  const response = await postResponse<{ color: string }, { cakeId: number }>(
-    "/api/cakes",
-    { color }
-  );
-  if (response) {
-    localStorage.setItem("cakeId", response.cakeId.toString());
-    return response.cakeId;
+  const response = await postResponse<
+    { color: string },
+    { statusCode: number; message: string; data: { cakeId: number } }
+  >("/api/cakes", { color });
+
+  if (response && response.data && response.data.cakeId) {
+    localStorage.setItem("cakeId", response.data.cakeId.toString());
+    return response.data.cakeId;
   }
 
   return null;

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,0 +1,119 @@
+import axios from "axios";
+import { refreshAccessToken } from "./refreshToken";
+
+export const instance = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  withCredentials: false,
+});
+
+instance.interceptors.request.use(
+  async (config) => {
+    let accessToken = localStorage.getItem("accessToken");
+
+    // 만약 엑세스 토큰이 없다면, 리프레시 토큰으로 엑세스 토큰을 갱신
+    if (!accessToken) {
+      const refreshToken = localStorage.getItem("refreshToken");
+      if (refreshToken) {
+        const newTokens = await refreshAccessToken(refreshToken);
+        if (newTokens) {
+          accessToken = newTokens.accessToken;
+        }
+      }
+    }
+
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// 응답 인터셉터를 추가하여 401 상태 코드에 대해 리프레시 토큰을 갱신
+//TODO: 백에게 리프레시 토큰 만료 에러 코드 물어보고 다시 설정 필요함
+instance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 만약 401 에러가 발생하고, 재시도한 적이 없다면
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      const refreshToken = localStorage.getItem("refreshToken");
+      if (refreshToken) {
+        const newTokens = await refreshAccessToken(refreshToken);
+        if (newTokens) {
+          originalRequest.headers[
+            "Authorization"
+          ] = `Bearer ${newTokens.accessToken}`;
+          return instance(originalRequest);
+        }
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+// GET 요청
+export const getResponse = async <T>(url: string): Promise<T | null> => {
+  try {
+    const response = await instance.get<T>(url);
+    return response.data;
+  } catch (error) {
+    return null;
+  }
+};
+
+// DELETE 요청
+export const deleteResponse = async (url: string): Promise<boolean> => {
+  try {
+    await instance.delete(url);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+// POST 요청 (응답 데이터 없음)
+export const postResponseNoData = async (url: string): Promise<boolean> => {
+  try {
+    await instance.post(url, {
+      headers: {
+        Authorization: `Bearer `,
+      },
+    });
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+// POST 요청 (응답 데이터 있음)
+export const postResponse = async <TRequest, TResponse>(
+  url: string,
+  body: TRequest
+): Promise<TResponse | null> => {
+  try {
+    const response = await instance.post<TResponse>(url, body);
+    return response.data;
+  } catch (error) {
+    return null;
+  }
+};
+
+// POST 요청 (응답 데이터 없음)
+export const postNoResponse = async <TRequest>(
+  url: string,
+  requestBody: TRequest
+): Promise<boolean> => {
+  try {
+    await instance.post(url, requestBody);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};

--- a/src/apis/refreshToken.ts
+++ b/src/apis/refreshToken.ts
@@ -1,0 +1,28 @@
+import { instance } from "./instance";
+interface RefreshTokenResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export const refreshAccessToken = async (
+  refreshToken: string
+): Promise<RefreshTokenResponse | null> => {
+  try {
+    const response = await instance.post<RefreshTokenResponse>(
+      "/api/token/access",
+      {
+        refreshToken,
+      }
+    );
+
+    if (response) {
+      localStorage.setItem("accessToken", response.data.accessToken);
+      localStorage.setItem("refreshToken", response.data.refreshToken);
+      return response.data;
+    }
+    return null;
+  } catch (error) {
+    console.error("Error refreshing access token:", error);
+    return null;
+  }
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,5 @@
-import React from "react";
+// import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/src/pages/intro/Intro.styled.ts
+++ b/src/pages/intro/Intro.styled.ts
@@ -5,7 +5,7 @@ export const IntroWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100%;
+  height: 100vh;
   gap: 2rem;
 `;
 
@@ -25,7 +25,7 @@ export const IntroText = styled.p`
 
 export const QuestionWrapper = styled.div`
   display: flex;
-  height: 100%;
+  height: 100vh;
   flex-direction: column;
   justify-content: center;
   align-items: center;
@@ -52,7 +52,7 @@ export const QuestionBtn = styled.section`
 
 export const ResultWrapper = styled.div`
   display: flex;
-  height: 100%;
+  height: 100vh;
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/src/pages/intro/Result.tsx
+++ b/src/pages/intro/Result.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import * as S from "./Intro.styled";
-import { postCake } from "@apis/cake/postCake";
+import { postCake } from "@apis/domain/cake/postCake";
 
 interface LocationState {
   resultPattern: string;
@@ -46,19 +46,23 @@ const Result: React.FC = () => {
     image: "/images/intro/cream-cake.png",
   };
 
+  const [isRequestSent, setIsRequestSent] = useState(false);
+
   useEffect(() => {
-    const sendCakeData = async () => {
-      const cakeId = await postCake(cake.name);
+    if (!isRequestSent) {
+      const sendCakeData = async () => {
+        const cakeId = await postCake(cake.name);
 
-      if (cakeId !== null) {
-        console.log("케이크 아이디 저장!:", cakeId);
-      } else {
-        console.error("케이크 아이디 저장 실패");
-      }
-    };
+        if (cakeId !== null) {
+          setIsRequestSent(true);
+        } else {
+          console.log("케이크 id 저장 실패");
+        }
+      };
 
-    sendCakeData();
-  }, [cake.name]);
+      sendCakeData();
+    }
+  }, [cake.name, isRequestSent]);
 
   return (
     <S.ResultWrapper>

--- a/src/pages/intro/Result.tsx
+++ b/src/pages/intro/Result.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import * as S from "./Intro.styled";
+import { postCake } from "@apis/cake/postCake";
 
 interface LocationState {
   resultPattern: string;
@@ -44,6 +45,20 @@ const Result: React.FC = () => {
     name: "순백의 생크림",
     image: "/images/intro/cream-cake.png",
   };
+
+  useEffect(() => {
+    const sendCakeData = async () => {
+      const cakeId = await postCake(cake.name);
+
+      if (cakeId !== null) {
+        console.log("케이크 아이디 저장!:", cakeId);
+      } else {
+        console.error("케이크 아이디 저장 실패");
+      }
+    };
+
+    sendCakeData();
+  }, [cake.name]);
 
   return (
     <S.ResultWrapper>

--- a/src/pages/login/Login.styled.ts
+++ b/src/pages/login/Login.styled.ts
@@ -4,7 +4,7 @@ export const LoginWrapper = styled.div`
   display: flex;
   flex-direction: column;
   color: white;
-  height: 100%;
+  height: 100vh;
   align-items: center;
   line-height: 22px;
 `;

--- a/src/pages/login/OAuthRedirectHandler.tsx
+++ b/src/pages/login/OAuthRedirectHandler.tsx
@@ -29,7 +29,7 @@ const OAuthRedirectHandler = () => {
       localStorage.setItem("accessToken", loginToken.accessToken);
       localStorage.setItem("refreshToken", loginToken.refreshToken);
 
-      navigate("/dailyCake");
+      navigate("/intro");
     }
   }, [loginToken, navigate]);
 
@@ -52,7 +52,7 @@ const OAuthRedirectHandler = () => {
         setLoginToken(tokenResponse.data.data);
       }
     } catch (error) {
-      console.error("❌ 토큰을 가져오는데 실패했습니다:", error);
+      console.error("토큰을 가져오는데 실패했습니다:", error);
     }
   };
   //Todo: 로딩 컴포넌트 생성

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,37 +1,38 @@
 {
-	"compilerOptions": {
-		"forceConsistentCasingInFileNames": true,
-		"baseUrl": ".",
-		"paths": {
-			"@components/*": ["src/components/*"],
-			"@styles/*": ["src/styles/*"],
-			"@routes/*": ["src/routes/*"],
-			"@layout/*": ["src/layout/*"],
-			"@pages/*": ["src/pages/*"],
-			"@atoms/*": ["src/atoms/*"],
-			"@hooks/*": ["src/hooks/*"]
-		},
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@styles/*": ["src/styles/*"],
+      "@routes/*": ["src/routes/*"],
+      "@layout/*": ["src/layout/*"],
+      "@pages/*": ["src/pages/*"],
+      "@atoms/*": ["src/atoms/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@apis/*": ["src/apis/*"]
+    },
 
-		"target": "ES2020",
-		"useDefineForClassFields": true,
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
-		"module": "ESNext",
-		"skipLibCheck": true,
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
 
-		/* Bundler mode */
-		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react-jsx",
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
 
-		/* Linting */
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
-	},
-	"include": ["src"],
-	"references": [{ "path": "./tsconfig.node.json" }]
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
       "@pages": path.resolve(__dirname, "src/pages"),
       "@atoms": path.resolve(__dirname, "src/atoms"),
       "@hooks": path.resolve(__dirname, "src/hooks"),
+      "@apis": path.resolve(__dirname, "src/apis"),
     },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       "@pages": path.resolve(__dirname, "src/pages"),
       "@atoms": path.resolve(__dirname, "src/atoms"),
       "@hooks": path.resolve(__dirname, "src/hooks"),
+      "@apis": path.resolve(__dirname, "src/apis"),
     },
   },
 });


### PR DESCRIPTION
## 💥 ISSUE

- closed #40

## ❗ WORK DESCRIPTION

- api method 생성했습니다.(instance.ts)
- instance.ts 보면 각 api method마다의 틀이 있습니다. 보고 맞게 사용하면 됩니다.
- 예시로는 src>apis>cake>postCake 확인하면 됩니다.


## 💻 주요 코드

- instance는 env에 저장된 백 서버 url입니다.
- 스웨거를 확인해본 결과 post나 get 성공 시 statusCode나 message가 안오지만, 실패하면 statuscode, message, data가 오는걸로 확인해 그렇게 구현해두었습니다.
- apI는 각 페이지에서 사용하지 말고, apis>domain에 구현 후 import해서 사용해 코드를 분리하면 좋을 것 같습니다.

```ts
// GET 요청
export const getResponse = async <T>(url: string): Promise<T | null> => {
  try {
    const response = await instance.get<T>(url);
    return response.data;
  } catch (error) {
    return null;
  }
};

// DELETE 요청
export const deleteResponse = async (url: string): Promise<boolean> => {
  try {
    await instance.delete(url);
    return true;
  } catch (error) {
    return false;
  }
};

// POST 요청 (응답 데이터 없음)
export const postResponseNoData = async (url: string): Promise<boolean> => {
  try {
    await instance.post(url, {
      headers: {
        Authorization: `Bearer `,
      },
    });
    return true;
  } catch (error) {
    return false;
  }
};

// POST 요청 (응답 데이터 있음)
export const postResponse = async <TRequest, TResponse>(
  url: string,
  body: TRequest
): Promise<TResponse | null> => {
  try {
    const response = await instance.post<TResponse>(url, body);
    return response.data;
  } catch (error) {
    return null;
  }
};

// POST 요청 (응답 데이터 없음)
export const postNoResponse = async <TRequest>(
  url: string,
  requestBody: TRequest
): Promise<boolean> => {
  try {
    await instance.post(url, requestBody);
    return true;
  } catch (error) {
    return false;
  }
};

```

## 📢 TO REVIEWERS

- 로그인 후 accessToken을 항상 요청 헤더에 넣도록 구현해두었습니다. 그런데 엑세스 토큰이 만료된 걸 백에서 어떻게 알려주는지 아직 몰라서 401 에러 코드로 해놓았습니다. 추후 확인이 필요합니다!
