### PR TITLE
[Feat] #43 - 소셜 페이지 api 연결 구현

### DIFF
--- a/src/apis/domain/social/getSocialCakes.ts
+++ b/src/apis/domain/social/getSocialCakes.ts
@@ -1,0 +1,14 @@
+import { getResponse } from "@apis/instance";
+
+export const getSocialCakes = async (
+	page: number = 1,
+	size: number = 10,
+): Promise<string[] | null> => {
+	const response = await getResponse<{
+		statusCode: number;
+		message: string;
+		data: string[];
+	}>(`/api/cakes/followers?page=${page}&size=${size}`);
+	if (response && response.data) return response.data;
+	return null;
+};

--- a/src/apis/domain/social/getSocialCupcakes.ts
+++ b/src/apis/domain/social/getSocialCupcakes.ts
@@ -1,0 +1,14 @@
+import { getResponse } from "@apis/instance";
+
+export const getSocialCupcakes = async (
+	page: number = 1,
+	size: number = 10,
+): Promise<string[] | null> => {
+	const response = await getResponse<{
+		statusCode: number;
+		message: string;
+		data: string[];
+	}>(`/api/cupcakes/follow?page=${page}&size=${size}`);
+	if (response && response.data) return response.data;
+	return null;
+};

--- a/src/pages/social/Social.tsx
+++ b/src/pages/social/Social.tsx
@@ -1,59 +1,38 @@
 import { SelectTap } from "@components/selectTap/SelectTap.tsx";
 import * as S from "./Social.styled.ts";
 import { useEffect, useState } from "react";
-import { SocialCupcake } from "@components/social/socialCupcake/SocialCupcake.tsx";
 import { SocialCake } from "@components/social/socialCake/SocialCake.tsx";
-
-const socailCakeData = [
-	{
-		likeNum: 12,
-		owner: "jeongbami",
-		liked: true,
-	},
-	{
-		likeNum: 8,
-		owner: "alsn",
-		liked: false,
-	},
-	{
-		likeNum: 2,
-		owner: "gildong",
-		liked: true,
-	},
-];
-
-const socialCupcakeData = [
-	{
-		feeling: "happy",
-		likenNum: 13,
-		writtenDate: "2025.10.24",
-		liked: false,
-		owner: "jeongbami",
-	},
-	{
-		feeling: "unrest",
-		likenNum: 8,
-		liked: true,
-		writtenDate: "2025.10.23",
-		owner: "gildongli",
-	},
-	{
-		feeling: "angry",
-		likenNum: 2,
-		liked: false,
-		writtenDate: "2025.10.22",
-		owner: "chillguy",
-	},
-];
+import { getSocialCakes } from "@apis/domain/social/getSocialCakes.ts";
+import { getSocialCupcakes } from "@apis/domain/social/getSocialCupcakes.ts";
 
 export const Social = () => {
 	const [numOfCakes, setNumOfCakes] = useState(0);
 	const val1 = `Cakes(${numOfCakes})`;
 	const val2 = "New Cupcakes";
 	const [selectedTap, setSelectedTap] = useState(val1);
+	const [socialCakeData, setSocialCakeData] = useState<string[]>([]);
+	const [socialCupcakeData, setSocialCupcakeData] = useState<string[]>([]);
+
+	const fetchSocialCakes = async () => {
+		const response = await getSocialCakes();
+		if (response) {
+			console.log("getSocialCakes API 응답 데이터:", response);
+			setSocialCakeData(response);
+			setNumOfCakes(response.length);
+		}
+	};
+
+	const fetchSocialCupcakes = async () => {
+		const response = await getSocialCupcakes();
+		if (response) {
+			console.log("getSocialCupcakes API 응답 데이터 : ", response);
+			setSocialCupcakeData(response);
+		}
+	};
 
 	useEffect(() => {
-		setNumOfCakes(14);
+		fetchSocialCakes();
+		fetchSocialCupcakes();
 	}, []);
 
 	useEffect(() => {
@@ -73,26 +52,14 @@ export const Social = () => {
 			<S.Content>
 				{selectedTap === val1 ? (
 					<S.CakeWrapper>
-						{socailCakeData.map((data, index) => (
-							<SocialCake
-								key={index}
-								liked={data.liked}
-								likedNum={data.likeNum}
-								owner={data.owner}
-							/>
+						{socialCakeData.map((data, index) => (
+							<SocialCake key={index} liked={false} likedNum={0} owner={data} />
 						))}
 					</S.CakeWrapper>
 				) : (
 					<S.CupCakeWrapper>
 						{socialCupcakeData.map((data, index) => (
-							<SocialCupcake
-								key={index}
-								feeling={data.feeling}
-								likenNum={data.likenNum}
-								owner={data.owner}
-								liked={data.liked}
-								writtenDate={data.writtenDate}
-							></SocialCupcake>
+							<SocialCake key={index} liked={false} likedNum={0} owner={data} />
 						))}
 					</S.CupCakeWrapper>
 				)}


### PR DESCRIPTION
## 💥 ISSUE

- closed #43 

## ❗ WORK DESCRIPTION

- 소셜 페이지 api 연결 구현

## 📸 SCREENSHOT

단순 api 구현이므로 사진 생략합니다.

## 💻 주요 코드

- Social.tsx에서 아래 부분을 추가하여 api로부터 받아온 데이터를 띄우도록 수정하였습니다.

```ts
const [socialCakeData, setSocialCakeData] = useState<string[]>([]);
	const [socialCupcakeData, setSocialCupcakeData] = useState<string[]>([]);

	const fetchSocialCakes = async () => {
		const response = await getSocialCakes();
		if (response) {
			console.log("getSocialCakes API 응답 데이터:", response);
			setSocialCakeData(response);
			setNumOfCakes(response.length);
		}
	};

	const fetchSocialCupcakes = async () => {
		const response = await getSocialCupcakes();
		if (response) {
			console.log("getSocialCupcakes API 응답 데이터 : ", response);
			setSocialCupcakeData(response);
		}
	};

```

## 📢 TO REVIEWERS

- 아직 친구가 아무도 없어서 빈 화면으로 표시됩니다.
- 케이크, 컵케이크 클릭 시 해당 페이지로 넘어가는 것은 친구 요청 및 친구데이터가 꾸려진 상황에서 수정해야 할 거 같습니다.
